### PR TITLE
Make SSL certificate verification configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default['sentry']['dsn'] = nil
 default['sentry']['enabled'] = true
+default['sentry']['verify_ssl'] = true

--- a/files/default/sentry.rb
+++ b/files/default/sentry.rb
@@ -5,6 +5,7 @@ module Raven
     class SentryHandler < ::Chef::Handler
       def initialize(node)
         Raven.configure(true) do |config|
+          config.ssl_verification = node['sentry']['verify_ssl']
           config.dsn = node['sentry']['dsn']
           config.logger = ::Chef::Log
           config.current_environment = node.chef_environment

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,7 +8,7 @@ directory node["chef_handler"]["handler_path"] do
 end.run_action(:create)
 
 chef_gem "sentry-raven" do
-  version "0.2"
+  version "0.4.6"
 end
 
 handler_file = ::File.join(node["chef_handler"]["handler_path"], 'sentry.rb')


### PR DESCRIPTION
- Adds node['sentry']['verify_ssl'] attribute (defaults to true)
- Bumps `sentry-raven` version to latest (0.4.6), supporting configuration of SSL verification
- Modifies handler to configure SSL verification behavior using new node attribute
