### PR TITLE
Include uuidtools in chef-sentry-handler

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,6 +7,8 @@ directory node["chef_handler"]["handler_path"] do
   action :nothing
 end.run_action(:create)
 
+chef_gem "uuidtools"
+
 chef_gem "sentry-raven" do
   version "0.4.6"
 end


### PR DESCRIPTION
This resolves a crashbug; uuidtools is a dependancy of sentry-raven.

```
Compiling Cookbooks...
Recipe: chef-sentry-handler::default
  * directory[/var/chef/handlers] action create (up to date)
  * chef_gem[sentry-raven] action install (up to date)
  * cookbook_file[/var/chef/handlers/sentry.rb] action create (up to date)
  * chef_handler[Raven::Chef::SentryHandler] action enable
================================================================================
Error executing action `enable` on resource 'chef_handler[Raven::Chef::SentryHandler]'
================================================================================


Gem::LoadError
--------------
Could not find uuidtools (>= 0) amongst [bigdecimal-1.1.0, bundler-1.1.5, chef-11.4.4, erubis-2.7.0, faraday-0.8.7, hashie-2.0.4, highline-1.6.18, io-console-0.3, ipaddress-0.8.0, json-1.5.4, mime-types-1.23, minitest-2.5.1, mixlib-authentication-1.3.0, mixlib-cli-1.3.0, mixlib-config-1.1.2, mixlib-log-1.6.0, mixlib-shellout-1.1.0, multi_json-1.7.2, multipart-post-1.2.0, net-ssh-2.6.7, net-ssh-gateway-1.2.0, net-ssh-multi-1.2.0, net-ssh-multi-1.1, ohai-6.16.0, rake-0.9.2.2, rdoc-3.9.4, rest-client-1.6.7, ruby-shadow-2.2.0, sentry-raven-0.4.5, sentry-raven-0.2, systemu-2.5.2, yajl-ruby-1.1.0]


Cookbook Trace:
---------------
/var/chef/cache/cookbooks/chef_handler/providers/default.rb:38:in `load'
/var/chef/cache/cookbooks/chef_handler/providers/default.rb:38:in `block (2 levels) in class_from_file'
/var/chef/cache/cookbooks/chef_handler/providers/default.rb:29:in `block in class_from_file'
/var/chef/cache/cookbooks/chef-sentry-handler/recipes/default.rb:29:in `from_file'
/var/chef/cache/cookbooks/factlink/recipes/new_base.rb:4:in `from_file'
/var/chef/cache/cookbooks/factlink-redis/recipes/default.rb:10:in `from_file'


Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/chef-sentry-handler/recipes/default.rb

 24: chef_handler "Raven::Chef::SentryHandler" do
 25:   source handler_file
 26:   supports({:exception => true})
 27:   arguments [node]
 28:   action :nothing
 29: end.run_action(node['sentry']['enabled'] ? :enable : :disable)



Compiled Resource:
------------------
# Declared in /var/chef/cache/cookbooks/chef-sentry-handler/recipes/default.rb:24:in `from_file'

chef_handler("Raven::Chef::SentryHandler") do
  action [:nothing]
  supports {:exception=>true}
  retries 0
  retry_delay 2
  cookbook_name "chef-sentry-handler"
  recipe_name "default"
  source "/var/chef/handlers/sentry.rb"
  arguments [node[factlink-redis-testserver]]
  class_name "Raven::Chef::SentryHandler"
end
```
