### PR TITLE
return if the run was successful or took place under a TTY

### DIFF
--- a/files/default/sentry.rb
+++ b/files/default/sentry.rb
@@ -16,7 +16,7 @@ module Raven
       end
 
       def report
-        return if success?
+        return if success? || STDOUT.tty?
         Raven.logger.info "Logging run failure to Sentry server"
         if exception
           evt = Raven::Event.capture_exception(exception)


### PR DESCRIPTION
If the `chef-client` or `chef-solo` session is attached to a TTY, it shouldn't send exceptions to sentry since a user theoretically would see the failure.
