### PR TITLE
Add version property to uuidtools chef_gem stanza

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,6 +8,8 @@ directory node["chef_handler"]["handler_path"] do
 end.run_action(:create)
 
 chef_gem "uuidtools"
+  version "2.1.5"
+end
 
 chef_gem "sentry-raven" do
   version "0.9.4"


### PR DESCRIPTION
Add a version property to the uuidtools chef_gem stanza.

In using this cookbook across hundreds of nodes, which are coincidentally NAT'd behind the same public IPv4 address, we started to notice strange network behavior that caused chef-client runs to hang while processing the uuidtools stanza.  Each node typically had two https connections stuck in an ESTABLISHED and/or CLOSE_WAIT state with data in recv-q.  We quickly surmised that this was symptomatic of chef checking for an updated uuidtools gem, and some kludgey rate limiting over at the gem repo causing our clients to hang indefinitely.  If you don't specify a gem version, upon each client run chef will attempt to retrieve the latest version info for that gem.  By specifying a suitable gem version we take a step to use the gem repo responsibly.
