### PR TITLE
replace unicode dash with ascii dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Depends on the `chef_handler` cookbook to activate the error handler.
 Attributes
 ==========
 
-* `node['sentry']['dsn']` – **Required** The DSN for your Sentry server.
+* `node['sentry']['dsn']` - **Required** The DSN for your Sentry server.
 * `node['sentry']['enabled']` - Boolean to enable/disable the error reporter. Defaults to `true`.
 
 Usage


### PR DESCRIPTION
Replace unicode dash ('–') with ascii dash ('-').

In older versions of chef-webui, not sure about webui in chef 12, attempting to view this cookbook would throw a charset mismatch error and prevent you from seeing the contents in the browser.  The culprit ended up being in the README.md file and ultimately the generated metadata.json file.  Curiously the dash right below the offending unicode dash is a standard ascii dash, so it's possible there was a cut and paste at fault somewhere along the line.
